### PR TITLE
Added "react-native-device-info" as dependency in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.9",
   "description": "React Native TextInput: it has the following features: Dynamic height based on user entered textValue and Scroll to last line while editing multilines",
   "main": "index.js",
+  "dependencies": {
+    "react-native-device-info": "1.4.3"
+  },
   "scripts": {
     "test": "npm start"
   },


### PR DESCRIPTION
This was necessary because if someone doesn't have this dependency installed (s)he will be getting error of `Unable to resolve module "react-native-device-info"`